### PR TITLE
await for the signHandler to finish

### DIFF
--- a/src/CleosUser.ts
+++ b/src/CleosUser.ts
@@ -35,7 +35,7 @@ class CleosUser extends User {
     * @param transaction  The transaction to be signed (a object that matches the RpcAPI structure).
     */
     signTransaction = async (transaction: any): Promise<SignTransactionResponse> => {
-        this.signHandler(transaction);
+        await this.signHandler(transaction);
         return this.returnEosjsTransaction(false, {});
     };
 


### PR DESCRIPTION
It is desirable to be able to react at the end of the signing handler and not immediately triggered.

# Fixes #13
