### PR TITLE
updating the eosjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telosnetwork/ual-cleos",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "",
   "main": "dist/index.js",
   "repository": {
@@ -19,14 +19,14 @@
     "name": "Jesse Schulman"
   },
   "dependencies": {
-    "eosjs": "^20.0.3",
+    "eosjs": "^22.1.0",
     "text-encoding": "^0.7.0",
     "typescript": "^4.7.4",
     "universal-authenticator-library": "0.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
-    "@babel/core": "^7.3.4",
+    "@babel/core": "^7.18.10",
     "@babel/plugin-proposal-class-properties": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
     "eslint": "^6.1.0",


### PR DESCRIPTION
# Fixes #15 

## Description
The following code was failing at compiling time because `ual-cleos` had an old `eosjs` dependency. 
```
Key.value = Numeric.publicKeyToLegacyString(
    Numeric.stringToPublicKey(Key.value)
);
```

I updated the version of the `eosjs` from `^20.0.3` to `^22.1.0` and therefore the version of the `ual-cleos` package itself to `1.13.1`
